### PR TITLE
Clicking on Icon to open Link in New Tab

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -15,7 +15,7 @@
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-     
+
     <title>Contact Us</title>
 </head>
 <body>
@@ -30,8 +30,8 @@
             <span style="color: #eb3750;">HackClub</span>
             <span style="color: #eb3750;">/></span>
             </div>
-        </a> 
-        
+        </a>
+
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -55,10 +55,10 @@
                 <input type="text" class="form-control-lg" placeholder="Message">
                 <button class="btn btn-danger">Send</button>
                 <div>
-                    <a href="https://github.com/HackClubRAIT"><i class="fa fa-github"></i></a>
-                    <a href="https://instagram.com/hackclubrait?utm_medium=copy_link"><i class="fa fa-instagram"></i></a>
-                    <a href="https://www.linkedin.com/company/hack-club-rait"><i class="fa fa-linkedin-square"></i></a>
-                    <a href="mailto:hackclubrait@gmail.com"><i class="fa fa-envelope"></i></a>          
+                    <a href="https://github.com/HackClubRAIT" target="_blank"><i class="fa fa-github"></i></a>
+                    <a href="https://instagram.com/hackclubrait?utm_medium=copy_link" target="_blank"><i class="fa fa-instagram"></i></a>
+                    <a href="https://www.linkedin.com/company/hack-club-rait" target="_blank"><i class="fa fa-linkedin-square"></i></a>
+                    <a href="mailto:hackclubrait@gmail.com" target="_blank"><i class="fa fa-envelope"></i></a>          
                 </div>
             </form>
             <div class="col-sm-6">


### PR DESCRIPTION
## What is the change?
I Have Made Changes in Contact us, When we click any of the Social Media Icons in the Contact us section they use to open in Current Tab, I fixed the issue and Now it Redirects To a New Tab 

## Related issue?
#110 

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

-   [x] I have followed the [Code of Conduct](https://github.com/HackClubRAIT/HackClubRAIT-Website.github.io/blob/ec224497bce316f7b4736a901f70688f251cca87/CODE_OF_CONDUCT.md).
-   [x] I have checked there aren't other open [Pull Requests](https://github.com/HackClubRAIT/HackClubRAIT-Website.github.io/pulls) for the same update/change.
-   [x] I have you tested the code before submission.
-   [x] I have commented on my code, particularly in hard-to-understand areas.
-   [x] My changes generates no new warnings.
-   [x] I'm a JWOC contributor.

